### PR TITLE
Added new about links

### DIFF
--- a/bmrc/templates/base.html
+++ b/bmrc/templates/base.html
@@ -78,8 +78,10 @@
                             <a class="navbar-link" href="/about/">About</a>
                             <div class="navbar-dropdown is-boxed">
                                 <a class="navbar-item" href="/about/">About the BMRC</a>
-                                <a class="navbar-item" href="/about/staff/">Staff &amp; Board Members</a>
-                                <a class="navbar-item" href="/about/membership">Membership</a>
+                                <a class="navbar-item" href="/about/membership-information/">Membership Information</a>
+                                <a class="navbar-item" href="/about/membership">Current Members</a>
+                                <a class="navbar-item" href="/about/board-committees/">Board &amp; Committees</a>
+                                <a class="navbar-item" href="/about/staff/">Staff</a>
                             </div>
                         </div>
                         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
Closes #54

- Added new about pages to nav.
- Admin view of all About pages for link checking: https://bmrc.lib.uchicago.edu/admin/pages/8/