### PR TITLE
Added partnerships to nav

### DIFF
--- a/bmrc/templates/base.html
+++ b/bmrc/templates/base.html
@@ -80,6 +80,7 @@
                                 <a class="navbar-item" href="/about/">About the BMRC</a>
                                 <a class="navbar-item" href="/about/membership-information/">Membership Information</a>
                                 <a class="navbar-item" href="/about/membership">Current Members</a>
+                                <a class="navbar-item" href="/about/partnerships/">Partnerships</a>
                                 <a class="navbar-item" href="/about/board-committees/">Board &amp; Committees</a>
                                 <a class="navbar-item" href="/about/staff/">Staff</a>
                             </div>


### PR DESCRIPTION
Closes #62

- Added "partnerships" to "About" drop-down in main navigation
- Page is published on production at: https://bmrc.lib.uchicago.edu/about/partnerships/