### PR TITLE
Add Black Visual Arts Research(er) to Programs dropdown menu

### DIFF
--- a/bmrc/templates/includes/nav.html
+++ b/bmrc/templates/includes/nav.html
@@ -36,6 +36,7 @@
                         <li><a class="dropdown-item" href="/programs/color-curtain-processing-project/">Color Curtain Processing Project</a></li>
                         <li><a class="dropdown-item" href="/programs/survey-initiative/">Survey Initiative</a></li>
                         <li><a class="dropdown-item" href="/programs/faculty-organizing-for-community-archives-support-focas-project/">Faculty Organizing for Community Archives Support (FOCAS) Project</a></li>
+                        <li><a class="dropdown-item" href="/programs/black-visual-arts-researcher/">Black Visual Arts Research(er)</a></li>
                     </ul>
                 </li>
                 <li class="nav-item dropdown">


### PR DESCRIPTION
Title: Add Black Visual Arts Research(er) to Programs dropdown menu

Fixes #115

Summary

Added the Black Visual Arts Research(er) program page to the Programs dropdown menu in the main navigation.
- Added new menu item at the end of Programs dropdown list
- Links to /programs/black-visual-arts-researcher/

Please verify the URL is correct.