### PR TITLE
Upgrade Wagtail and Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0.14
-wagtail==6.1.3
+Django==5.2.6
+wagtail==7.0.3
 django-compressor
 django-libsass
 django-static-precompiler


### PR DESCRIPTION
Fixes #119

**Changes in this request**:
- Upgrades to `Django 5.2.6` 
- Upgrades to `Wagtail 7.0.3`

## Django release notes
- https://docs.djangoproject.com/en/5.2/releases/5.1/
- https://docs.djangoproject.com/en/5.2/releases/5.2/

## Wagtail release notes
- https://docs.wagtail.org/en/stable/releases/6.2.html
- https://docs.wagtail.org/en/stable/releases/6.3.html
- https://docs.wagtail.org/en/stable/releases/6.4.html
- https://docs.wagtail.org/en/stable/releases/7.0.html

This can be [previewed on bmrc-test](https://bmrc-test.lib.uchicago.edu/).