### PR TITLE
155 allow dev site docker container to talk to mark logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    network_mode: "host"
     build: .
     volumes:
       - .:/app                          # Bind mount for live code editing

--- a/portal/models.py
+++ b/portal/models.py
@@ -461,9 +461,6 @@ class PortalHomePage(PortalBasePage):
         discover_more_facet_uri = 'https://bmrc.lib.uchicago.edu/{}/'.format(
             discover_more_facet
         )
-        # discover_more_facet_image = Image.objects.get(
-            # title='homepage_facet_image_{}.jpg'.format(discover_more_facet)
-        # )
         collections = get_collections(
             settings.MARKLOGIC_SERVER,
             settings.MARKLOGIC_USERNAME,
@@ -487,7 +484,6 @@ class PortalHomePage(PortalBasePage):
                 'discover_more_facet_plural': PortalBasePage.portal_facets[
                     discover_more_facet
                 ][1],
-                # 'discover_more_facet_image': discover_more_facet_image,
                 'discover_more_facet_uri': discover_more_facet_uri,
                 'discover_more_topic': discover_more_topic,
                 'discover_more_topic_uri': '/portal/search/?f='

--- a/portal/models.py
+++ b/portal/models.py
@@ -461,9 +461,9 @@ class PortalHomePage(PortalBasePage):
         discover_more_facet_uri = 'https://bmrc.lib.uchicago.edu/{}/'.format(
             discover_more_facet
         )
-        discover_more_facet_image = Image.objects.get(
-            title='homepage_facet_image_{}.jpg'.format(discover_more_facet)
-        )
+        # discover_more_facet_image = Image.objects.get(
+            # title='homepage_facet_image_{}.jpg'.format(discover_more_facet)
+        # )
         collections = get_collections(
             settings.MARKLOGIC_SERVER,
             settings.MARKLOGIC_USERNAME,
@@ -487,7 +487,7 @@ class PortalHomePage(PortalBasePage):
                 'discover_more_facet_plural': PortalBasePage.portal_facets[
                     discover_more_facet
                 ][1],
-                'discover_more_facet_image': discover_more_facet_image,
+                # 'discover_more_facet_image': discover_more_facet_image,
                 'discover_more_facet_uri': discover_more_facet_uri,
                 'discover_more_topic': discover_more_topic,
                 'discover_more_topic_uri': '/portal/search/?f='


### PR DESCRIPTION
Fixes #155.

The `network_mode: "host"` option in `docker-compose.yml` allows the Docker container to curl to Mark Logic from as the host machine's user (and from the host machine's IP), rather than from the container's own private IP and as its root user.  With this option turned on, as long as the developer is running the BMRC site from a machine that has permission to access Mark Logic, the Portal should work in dev mode.
