### PR TITLE
Add item to navbar

### DIFF
--- a/bmrc/static/css/_navbar.scss
+++ b/bmrc/static/css/_navbar.scss
@@ -33,6 +33,7 @@ $navbar-height: 70px;
 
                     ul.dropdown-menu {
                         --bs-dropdown-item-padding-y: 0.5rem;
+                        --bs-dropdown-min-width: 20rem;
                     }
 
                     a.nav-link {

--- a/bmrc/templates/includes/nav.html
+++ b/bmrc/templates/includes/nav.html
@@ -12,7 +12,7 @@
                     <a class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" href="/about/">About</a>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="/about/">About the BMRC</a></li>
-                        <li><a class="dropdown-item" href="/about/the-founding-of-the-bmrc-oral-history-project/">The Founding of the BMRC Oral History Project</a></li>
+                        <li><a class="dropdown-item" href="/about/the-founding-of-the-bmrc-oral-history-project/">Oral History Project</a></li>
                         <li><a class="dropdown-item" href="/about/membership-information/">Membership Information</a></li>
                         <li><a class="dropdown-item" href="/about/membership">Current Members</a></li>
                         <li><a class="dropdown-item" href="/about/partnerships/">Partnerships</a></li>

--- a/bmrc/templates/includes/nav.html
+++ b/bmrc/templates/includes/nav.html
@@ -12,6 +12,7 @@
                     <a class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" href="/about/">About</a>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="/about/">About the BMRC</a></li>
+                        <li><a class="dropdown-item" href="/about/the-founding-of-the-bmrc-oral-history-project/">The Founding of the BMRC Oral History Project</a></li>
                         <li><a class="dropdown-item" href="/about/membership-information/">Membership Information</a></li>
                         <li><a class="dropdown-item" href="/about/membership">Current Members</a></li>
                         <li><a class="dropdown-item" href="/about/partnerships/">Partnerships</a></li>


### PR DESCRIPTION
Fixes #159

Summary

The About dropdown was missing the Oral History Project page, and the nav dropdowns were too narrow for their longer link labels.
- Added an "Oral History Project" link to the About dropdown, directly below "About the BMRC" (per BMRC staff request)
- Set `--bs-dropdown-min-width: 20rem;` on the nav dropdowns so longer labels have room

Testing:
- Recompile SCSS / collectstatic, then load any page and open the nav dropdowns.
- Confirm the About dropdown lists the new "Oral History Project" item directly below "About the BMRC" and that it links to /about/the-founding-of-the-bmrc-oral-history-project/.
- Confirm all dropdowns (especially Programs, with its long FOCAS item) are wider and their labels wrap cleanly rather than being cramped.
